### PR TITLE
Scope z<9 label dir rules

### DIFF
--- a/labels.mss
+++ b/labels.mss
@@ -389,7 +389,7 @@
     }
   }
 
-  [zoom<9] {
+  [type='city'][zoom<9] {
     // beyond this point, labels are sufficiently dense that Winston-Salem,
     // NC, Spartanburg, SC, etc. bump other labels in the buffered area
     [ldir=~'W'] {


### PR DESCRIPTION
Rule should have equivalent effect on style as place features < z9 are only `type=city`.

Reduces generated XML size to `688k`. See https://github.com/stamen/pinterest.tm2/issues/8 for background.
